### PR TITLE
Support JSON status page parsing

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,6 +7,7 @@ endif
 GO_CMD ?= go
 GO_LDFLAGS:=
 BUILD_TAGS:=
+GO111MODULE:=off
 
 ifndef REPO_VERSION
 REPO_VERSION := $(shell ./.version)

--- a/README.md
+++ b/README.md
@@ -9,35 +9,6 @@ This code-base is horrible; it was predominantly written in a weekend, porting
 from some very organic Python.  Do not use this as an example of how to do
 things in Golang.
 
-Bit Rot 2021 Edition
---------------------
-
-**This code is old and the dependencies have rotted away**
-
-For the Gokogiri dependency you will need libxml development headers installed
-(for APT-based systems, incant `apt-get install libxml2-dev`),
-and a code fix applied to
-`~/go/src/github.com/moovweb/gokogiri/xml/document.go` :
-
-```diff
-diff --git a/xml/document.go b/xml/document.go
-index 5645239..63f2a8b 100644
---- a/xml/document.go
-+++ b/xml/document.go
-@@ -327,7 +328,7 @@ func (document *XmlDocument) CreateTextNode(data string) (text *TextNode) {
- 	dataPtr := unsafe.Pointer(&dataBytes[0])
- 	nodePtr := C.xmlNewText((*C.xmlChar)(dataPtr))
- 	if nodePtr != nil {
--		nodePtr.doc = (*_Ctype_struct__xmlDoc)(document.DocPtr())
-+		nodePtr.doc = (*C.xmlDoc)(document.DocPtr())
- 		text = NewNode(unsafe.Pointer(nodePtr), document).(*TextNode)
- 	}
- 	return
-```
-
-Logs are written to the file `sksdaemon.log` in the current working directory, by default, so further diagnostics are available there.
-
-
 Overview
 --------
 
@@ -88,6 +59,11 @@ To-Do
 
 Building
 --------
+
+You will need development headers installed:
+
+* Debian/Ubuntu etc: `apt-get install libxml2-dev`
+* MacOS: `brew install libxml2`
 
 To fetch the code, all dependencies, updating them, and install the command,
 then run:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Bit Rot 2021 Edition
 
 **This code is old and the dependencies have rotted away**
 
-To even build this, you'll need `export GO111MODULE=off` for modern Go
-compilers, and then for the Gokogiri dependency you will need
-libxml development headers installed and a code fix applied to
+For the Gokogiri dependency you will need libxml development headers installed
+(for APT-based systems, incant `apt-get install libxml2-dev`),
+and a code fix applied to
 `~/go/src/github.com/moovweb/gokogiri/xml/document.go` :
 
 ```diff
@@ -35,10 +35,7 @@ index 5645239..63f2a8b 100644
  	return
 ```
 
-After that, note that the default `-spider-start-host` has gone, so spidering
-will fail.  You will minimally need that option.  Logs are written to the file
-`sksdaemon.log` in the current working directory, by default, so further
-diagnostics are available there.
+Logs are written to the file `sksdaemon.log` in the current working directory, by default, so further diagnostics are available there.
 
 
 Overview

--- a/countries_test.go
+++ b/countries_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 )
 
-const checkSksHostname = "sks-peer.spodhuis.org"
+const checkSksHostname = "pgpkeys.eu"
 const checkSksIPCount = 2
-const checkSksCountry = "NL"
+const checkSksCountry = "FR"
 const checkSksExpectIPv6HasCountry = false
 
 func TestCountrySpodhuis(t *testing.T) {

--- a/html_templates.go
+++ b/html_templates.go
@@ -26,7 +26,7 @@ var serveTemplates map[string]*template.Template
 func genNamespace() map[string]interface{} {
 	ns := make(map[string]interface{}, 50)
 	ns["Maintainer"] = *flMaintEmail
-	ns["MyHostname"] = *flHostname
+	ns["StartHost"] = *flSpiderStartHost
 	ns["MyStylesheet"] = *flMyStylesheet
 	ns["Warning"] = ""
 	return ns
@@ -58,14 +58,14 @@ func prepareTemplates() {
 
 	kPAGE_TEMPLATE_HEAD := kPAGE_TEMPLATE_BASIC_HEAD + `
   <link rev="made" href="mailto:{{.Maintainer}}">
-  <title>{{.MyHostname}} Peer Mesh</title>
+  <title>SKS Peer Mesh</title>
  </head>
  <body>
-  <h1>{{.MyHostname}} Peer Mesh</h1>
+  <h1>SKS Peer Mesh</h1>
 {{.Warning}}
 {{.Scanning_active}}
   <div class="explain">
-   Entries at depth 1 are direct peers of <span class="hostname">{{.MyHostname}}</span>.
+   Entries at depth 1 are direct peers of <span class="hostname">{{.StartHost}}</span>.
    Others are seen by spidering the peers.
   </div>
   <table class="sks peertable">

--- a/main.go
+++ b/main.go
@@ -30,10 +30,9 @@ import (
 )
 
 var (
-	flSpiderStartHost    = flag.String("spider-start-host", "sks-peer.spodhuis.org", "Host to query to start things rolling")
+	flSpiderStartHost    = flag.String("spider-start-host", "pgpkeys.eu", "Host to query to start things rolling")
 	flListen             = flag.String("listen", "localhost:8001", "port to listen on with web-server")
 	flMaintEmail         = flag.String("maint-email", "webmaster@spodhuis.org", "Email address of local maintainer")
-	flHostname           = flag.String("hostname", "sks.spodhuis.org", "Hostname to use in generated pages")
 	flMyStylesheet       = flag.String("stylesheet", "/styles/sks-peers.css", "CSS Style sheet to use")
 	flSksMembershipFile  = flag.String("sks-membership-file", "/var/sks/membership", "SKS Membership file")
 	flSksPortRecon       = flag.Int("sks-port-recon", 11370, "Default SKS recon port")

--- a/server_info.go
+++ b/server_info.go
@@ -26,14 +26,12 @@ import (
 	"strings"
 	"sync"
 	"time"
-)
 
-// "go-html-transform" -- crashes parsing SKS output
-// ehtml "exp/html" -- handles it, no xpath
+	// "go-html-transform" -- crashes parsing SKS output
+	// ehtml "exp/html" -- handles it, no xpath
 
-import (
-	htmlp "github.com/moovweb/gokogiri/html"
-	xml "github.com/moovweb/gokogiri/xml"
+	htmlp "github.com/sergioangulo/gokogiri/html"
+	xml "github.com/sergioangulo/gokogiri/xml"
 )
 
 type SksNode struct {


### PR DESCRIPTION
This allows Hockeypuck servers to be correctly spidered without the server operator having to fake an SKS stats page in HTML.